### PR TITLE
Increase consistency with blank line before return

### DIFF
--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -37,6 +37,7 @@ public class FindCommand extends Command {
         TaskList filtered = taskList.filter(keyword);
         if (filtered.getTaskList().isEmpty()) {
             ui.showOutput("No matching task found!");
+
             return "No matching task found!";
         } else {
             ui.showOutput("Here are the matching tasks in your list:");

--- a/src/main/java/duke/controller/DialogBox.java
+++ b/src/main/java/duke/controller/DialogBox.java
@@ -77,6 +77,7 @@ public class DialogBox extends HBox {
     public static DialogBox getDukeDialog(String text, Image img) {
         var db = new DialogBox(text, img);
         db.flip();
+
         return db;
     }
 }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -60,6 +60,7 @@ public abstract class Task {
      */
     public Task setStatus(boolean status) {
         this.status = status;
+
         return this;
     }
 

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -48,6 +48,7 @@ public class TaskList {
      */
     public TaskList add(Task task) {
         list.add(task);
+
         return this;
     }
 
@@ -63,6 +64,7 @@ public class TaskList {
             throw new DukeException("Task " + (index + 1) + " does not exist!");
         }
         list.remove(index);
+
         return this;
     }
 
@@ -85,6 +87,7 @@ public class TaskList {
     public TaskList filter(String keyword) {
         List<Task> filtered = list.stream().filter(task -> task.title.contains(keyword))
                 .collect(Collectors.<Task>toList());
+
         return new TaskList(filtered);
     }
 
@@ -94,6 +97,7 @@ public class TaskList {
         for (int i = 0; i < list.size(); i++) {
             ret += (i + 1) + ") " + list.get(i).toString() + "\n";
         }
+
         return ret;
     }
 }


### PR DESCRIPTION
Some return statements have no blank line before them.

Having blank line before return statements increases consistency in code quality.